### PR TITLE
Changed folder 2 segments to green

### DIFF
--- a/result_manager.py
+++ b/result_manager.py
@@ -402,6 +402,11 @@ def load_data(folder_number):
     dep3_mesh = meshes["dep3"]
     mesh_idx = meshes["mesh_idx"]
 
+    # Check if somehow 360 wrapping matters
+    lon1_mesh[lon1_mesh < 0] = lon1_mesh[lon1_mesh < 0] + 360
+    lon2_mesh[lon2_mesh < 0] = lon2_mesh[lon2_mesh < 0] + 360
+    lon3_mesh[lon3_mesh < 0] = lon3_mesh[lon3_mesh < 0] + 360
+
     # Calculate element geometry
     tri_leg1 = np.transpose(
         [

--- a/result_manager.py
+++ b/result_manager.py
@@ -572,36 +572,36 @@ def load_data(folder_number):
     fault_proj_polygons_y = []
     fault_proj_dips = []
     fault_proj_names = []
-    
+
     for i in range(len(segment)):
         dip_deg = segment["dip"].iloc[i]
         locking_depth = segment["locking_depth"].iloc[i]
-        
+
         # Only create projection polygons for non-vertical faults
         if abs(dip_deg - 90.0) > 1e-6:
             # Calculate bottom edge coordinates
             lon1_bot, lat1_bot, lon2_bot, lat2_bot = calculate_fault_bottom_edge(
                 segment["lon1"].iloc[i],
-                segment["lat1"].iloc[i], 
+                segment["lat1"].iloc[i],
                 segment["lon2"].iloc[i],
                 segment["lat2"].iloc[i],
                 locking_depth,
-                dip_deg
+                dip_deg,
             )
-            
+
             # Convert to web mercator
             x1_bot, y1_bot = wgs84_to_web_mercator(lon1_bot, lat1_bot)
             x2_bot, y2_bot = wgs84_to_web_mercator(lon2_bot, lat2_bot)
-            
+
             # Create polygon coordinates (top edge -> bottom edge -> close)
             poly_x = np.array([x1_seg[i], x2_seg[i], x2_bot, x1_bot, x1_seg[i]])
             poly_y = np.array([y1_seg[i], y2_seg[i], y2_bot, y1_bot, y1_seg[i]])
-            
+
             fault_proj_polygons_x.append(poly_x)
             fault_proj_polygons_y.append(poly_y)
             fault_proj_dips.append(dip_deg)
             fault_proj_names.append(segment["name"].iloc[i])
-    
+
     fault_proj_source.data = {
         "xpoly": fault_proj_polygons_x,
         "ypoly": fault_proj_polygons_y,
@@ -909,7 +909,7 @@ tde_perim_obj_2 = fig.multi_line(
 # Folder 1: Fault surface projections
 fault_proj_obj_1 = fig.patches(
     xs="xpoly",
-    ys="ypoly", 
+    ys="ypoly",
     source=fault_proj_source_1,
     fill_alpha=0.3,
     fill_color="lightblue",
@@ -918,14 +918,14 @@ fault_proj_obj_1 = fig.patches(
     visible=False,
 )
 
-# Folder 2: Fault surface projections  
+# Folder 2: Fault surface projections
 fault_proj_obj_2 = fig.patches(
     xs="xpoly",
     ys="ypoly",
-    source=fault_proj_source_2, 
+    source=fault_proj_source_2,
     fill_alpha=0.3,
-    fill_color="lightcoral",
-    line_color="red",
+    fill_color="lightgreen",
+    line_color="green",
     line_width=1,
     line_dash="dashed",
     visible=False,
@@ -966,9 +966,9 @@ seg_obj_1 = fig.multi_line(
 seg_obj_2 = fig.multi_line(
     xs="xseg",
     ys="yseg",
-    line_color="blue",
+    line_color="green",
     source=segsource_2,
-    line_width=1,
+    line_width=3,
     line_dash="dashed",
     visible=True,
 )
@@ -1621,7 +1621,8 @@ tde_radio_1.js_on_change(
     "active", CustomJS(args=dict(source=tdesource_1), code=slip_component_callback_js)
 )
 fault_proj_checkbox_1.js_on_change(
-    "active", CustomJS(args={"plot_object": fault_proj_obj_1}, code=checkbox_callback_js)
+    "active",
+    CustomJS(args={"plot_object": fault_proj_obj_1}, code=checkbox_callback_js),
 )
 
 # Folder 2
@@ -1671,7 +1672,8 @@ tde_radio_2.js_on_change(
     "active", CustomJS(args=dict(source=tdesource_2), code=slip_component_callback_js)
 )
 fault_proj_checkbox_2.js_on_change(
-    "active", CustomJS(args={"plot_object": fault_proj_obj_2}, code=checkbox_callback_js)
+    "active",
+    CustomJS(args={"plot_object": fault_proj_obj_2}, code=checkbox_callback_js),
 )
 
 # Shared between folder 1 and 2


### PR DESCRIPTION
Two visual changes to Folder 2's segments: 

1. Changed traces of segments to dashed green lines with line width of 3. These segments are placed beneath the thinner solid blue lines of Folder 1. The thicker lines look a little goofy at global scale but nicer when zoomed in, which is the typical use case. Below I show how it looks with a line width of 3 and width of 2; with standard green the dashed lines are practically  invisible above the blue when the line width is 1. 
2. Changed surface projections of dipping segments to translucent light green, following the style of Folder 1's projections. I think switching to green is helpful because the light coral color that was used previously could be confused with a slow positive slip rate on the blue-white-red color map!  

Line width of 3: 
<img width="398" height="364" alt="Screenshot 2025-08-15 at 9 58 31 AM" src="https://github.com/user-attachments/assets/de9e4ab0-ed26-4d6e-a78d-70afe702d37a" />

Line width of 2: 
<img width="559" height="482" alt="Screenshot 2025-08-15 at 10 02 27 AM" src="https://github.com/user-attachments/assets/7f45495c-9747-4a5c-9326-640967bcd096" />
